### PR TITLE
sql_export : moved to menu position where it doesn't obscure "my dash…

### DIFF
--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -66,7 +66,7 @@
 
 
     <menuitem id="sql_export_menu" name="Sql Export"
-        parent="base.menu_reporting_dashboard" sequence="80"/>
+        parent="base.menu_board_root" sequence="800"/>
 
     <menuitem id="sql_export_menu_view" name="Sql Export" parent="sql_export_menu" action="sql_export_tree_action" sequence="1"/>
 


### PR DESCRIPTION
…board"

Dashboard should be the leading/opening page on any master menu.